### PR TITLE
fix: use directories field for docker and uv ecosystems in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,14 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "docker"
-    directory: "/{{cookiecutter.project_dir_name}}"
+    directories:
+      - "/{{cookiecutter.project_dir_name}}"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "uv"
-    directory: "/{{cookiecutter.project_dir_name}}"
+    directories:
+      - "/{{cookiecutter.project_dir_name}}"
     schedule:
       interval: "weekly"
 


### PR DESCRIPTION
The `directory` field does not support glob patterns. The cookiecutter template path `/{{cookiecutter.project_dir_name}}` contains curly braces which are glob characters, causing Dependabot validation to fail. Switching to `directories` (which explicitly supports globs) resolves the error.