### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/klee1611/cookiecutter-fastapi-mongo/security/code-scanning/2](https://github.com/klee1611/cookiecutter-fastapi-mongo/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted to the minimum required scope.  
For this lint workflow, the best non-breaking fix is to set workflow-level:

- `contents: read`

This allows checkout and read-only repository access while avoiding unnecessary write grants.  
Edit `.github/workflows/lint.yml` by inserting `permissions:` after the trigger section (`on:` block) and before `jobs:`. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
