### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/klee1611/cookiecutter-fastapi-mongo/security/code-scanning/1](https://github.com/klee1611/cookiecutter-fastapi-mongo/security/code-scanning/1)

In general, the fix is to add a `permissions` block specifying the minimal required scopes for the GITHUB_TOKEN, either at the top level of the workflow (to apply to all jobs) or within the `ci` job. Since this workflow only checks out code and runs tests and does not perform any write operations via the token, restricting `contents` to `read` is sufficient.

The best minimal change without altering existing behavior is to add a `permissions` block at the workflow root, right after the `name: CI` line (or after the `on:` block—both are valid, but placing it under the name keeps the diff small and clear). We will set `contents: read`, which is the standard baseline for read-only access. No imports or external dependencies are required; this is purely a YAML configuration change within `.github/workflows/ci.yml`.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between line 1 (`name: CI`) and line 2 (`on:`).
- Leave all jobs and steps as they are.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
