### PR TITLE
fix: use valid placeholders in pyproject.toml for Dependabot uv compa…

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+# Restore project metadata in pyproject.toml.
+# The template uses valid placeholder values ("app", "0.1.0") so that
+# Dependabot can parse the file. Cookiecutter renders its variables inside
+# this hook before execution, so the replacements below produce real values.
+python3 - <<'PYEOF'
+with open("pyproject.toml", "r") as f:
+    content = f.read()
+content = content.replace('name = "app"', 'name = "{{cookiecutter.app_name}}"', 1)
+content = content.replace('version = "0.1.0"', 'version = "{{cookiecutter.app_version}}"', 1)
+with open("pyproject.toml", "w") as f:
+    f.write(content)
+PYEOF
+
 # Check if uv is installed
 if ! command -v uv &> /dev/null; then
     echo "⚠️  uv is not installed. Please install it first:"

--- a/{{cookiecutter.project_dir_name}}/pyproject.toml
+++ b/{{cookiecutter.project_dir_name}}/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "{{cookiecutter.app_name}}"
-version = "{{cookiecutter.app_version}}"
+name = "app"
+version = "0.1.0"
 description = ""
 authors = [{name = "{{cookiecutter.author}}"}]
 requires-python = ">=3.14"


### PR DESCRIPTION
fix: use valid placeholders in pyproject.toml for Dependabot uv compatibility

Dependabot's uv updater runs `uv lock` against the template's pyproject.toml, which contains Cookiecutter variables ({{cookiecutter.app_name}}, {{cookiecutter.app_version}}) that are not valid Python package name or PEP 440 version strings, causing every update attempt to fail with 'pyproject.toml not parseable'.

Replace the two invalid fields with valid placeholders ('app', '0.1.0') so Dependabot can parse and update the file. The post-generation hook restores the actual Cookiecutter values before uv sync runs, so generated projects are unaffected.